### PR TITLE
fix: add pre-compile normalize_ops to prevent stride mismatch in comp…

### DIFF
--- a/src/targets/gpu/compile_ops.cpp
+++ b/src/targets/gpu/compile_ops.cpp
@@ -327,12 +327,29 @@ struct compile_manager
         }
         par_compile(compiles.size(), [&](auto i) { compiles[i](); });
 
-        // Replace and/or benchmark
-        for(const auto& cp : cps)
+        // Replace and/or benchmark.
+        // When a precompile_op is replaced with a code_object_op, its output shape
+        // may change (e.g. when the code_object_op's output uses the allocation
+        // buffer's strides rather than the precompile_op's computed strides).
+        // If a downstream precompile_op in this loop has the replaced instruction
+        // as an input, its actual input shapes now differ from the expected_inputs
+        // captured during parallel compilation, causing a shape mismatch.  Mark
+        // such plans for re-compilation with the updated shapes.
+        for(auto& cp : cps)
         {
             if(cp.results.empty())
                 continue;
-            cp.replace(m);
+            try
+            {
+                cp.replace(m);
+            }
+            catch(const std::exception&)
+            {
+                // Shape mismatch — clear results so this plan stays in cps
+                // and gets re-compiled with the current (post-replacement) shapes.
+                cp.results.clear();
+                cp.config = nullopt;
+            }
         }
 
         // Remove compile_plan already executed
@@ -357,7 +374,10 @@ void compile_ops::apply(module& m) const
     }
     cm.update_configs();
     cm.compile(m);
-    // Compile already tuned configs
+    // Re-fetch tuning configs: any plans that failed during the first compile
+    // due to input shape changes need fresh configs for the updated shapes.
+    cm.update_configs();
+    // Compile already tuned configs and re-compile any plans that failed above
     cm.compile(m);
     assert(cm.cps.empty());
 }

--- a/src/targets/gpu/target.cpp
+++ b/src/targets/gpu/target.cpp
@@ -255,6 +255,8 @@ std::vector<pass> target::get_passes(migraphx::context& gctx, const compile_opti
         dead_code_elimination{},
         adjust_allocation{gpu_allocation_model{}},
         dead_code_elimination{},
+        normalize_ops{},
+        dead_code_elimination{},
         compile_ops{&ctx, options.exhaustive_tune},
         dead_code_elimination{},
         promote_literals{},


### PR DESCRIPTION
Root cause: ~30 transformation passes between the first normalize_ops and compile_ops create new ops with un-normalized attributes. During parallel compilation in compile_ops, strides are captured at compile time. When upstream code_objects are sequentially replaced, their output strides change, causing downstream code_objects to fail with 'Input shapes have changed'.

Fix:
- target.cpp: Add normalize_ops{} + dead_code_elimination{} immediately before compile_ops in the GPU pass pipeline. All ops are fully normalized before any GPU kernel compilation begins.
- compile_ops.cpp: Add try/catch safety net around sequential replacement. If a shape mismatch still occurs, failed plans are retained and re-compiled with updated shapes. Also adds a second compile pass for re-compilation.

Tested: Full Topaz SLMU model (8514 nodes) compiles successfully with no stride mismatch error. Previously failed after ~6h44m of compilation.